### PR TITLE
修复编译问题：调换头文件顺序

### DIFF
--- a/arch/loongarch/kernel/env.c
+++ b/arch/loongarch/kernel/env.c
@@ -1,14 +1,14 @@
-#include <asm/boot_param.h>
-#include <asm/bootinfo.h>
-#include <asm/fw.h>
-#include <asm/loongarch.h>
-#include <asm/page.h>
 #include <xkernel/atomic.h>
 #include <xkernel/init.h>
 #include <xkernel/kernel.h>
 #include <xkernel/printk.h>
 #include <xkernel/string.h>
 #include <xkernel/types.h>
+#include <asm/boot_param.h>
+#include <asm/bootinfo.h>
+#include <asm/fw.h>
+#include <asm/loongarch.h>
+#include <asm/page.h>
 
 #define EPERM 1
 #define PAGE_MASK (~(PAGE_SIZE - 1))


### PR DESCRIPTION
龙芯架构中s8也是一个寄存器名，编译时出现问题。通过调整头文件顺序解决。